### PR TITLE
New options for training: ConvNeXt framework, early stopping with patience, and extra augmentations

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,31 +150,34 @@ device: cuda:0  # set to local gpu device
 num_workers: 8  # number of cores
 
 # dataset parameters
-num_classes: 53 #might need to be adjusted based on the classes file
+num_classes: 53 # might need to be adjusted based on the classes file
 training_set: "/path/to/save/train_data.csv"
 validate_set: "/path/to/save/validate_data.csv"
 test_set: "/path/to/save/test_data.csv"
 class_file: "/home/usr/machinelearning/Models/Animl-Test/test_classes.txt" 
 
 # training hyperparameters
-architecture: "efficientnet_v2_m"
+architecture: "efficientnet_v2_m" # or choose "convnext_base"
 image_size: [299, 299]
-num_epochs: 100
 batch_size: 16
-
+num_epochs: 100
+checkpoint_frequency: 10
+patience: 10 # remove from config file to disable
 learning_rate: 0.003
 weight_decay: 0.001
 
 # overwrite .pt files
 overwrite: False
-
 experiment_folder: '/home/usr/machinelearning/Models/Animl-Test/'
+
+# model to test
+active_model: '/home/usr/machinelearning/Models/Animl-Test/best.pt' 
 ```
 
 class_file refers to a flle that contains index,label pairs. For example:<br>
 test_class.txt
 ```
-id,Code,Species,Common
+id,class,Species,Common
 1,cat, Felis catus, domestic cat
 2,dog, Canis familiaris, domestic dog
 ```
@@ -185,7 +188,7 @@ id,Code,Species,Common
 ```bash
 python -m animl.train --config /path/to/config.yaml
 ```
-Every 10 epochs, the model will be checkpointed to the 'experiment_folder' parameter in the config file, and will contain performance metrics for selection.
+Every 10 epochs (or define custom 'checkpoint_frequency'), the model will be checkpointed to the 'experiment_folder' parameter in the config file, and will contain performance metrics for selection.
 
 
 5. Testing of a model checkpoint can be done with the "test.py" module.  Add an 'active_model' parameter to the config file that contains the path of the checkpoint to test.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Training workflows are still under development. Please submit Issues as you come
    This function splits each label proportionally by the given percentages, by default 0.7 training, 0.2 validation, 0.1 Test.
 ```python
 from animl import split
-train, val, test, stats = train_val_test(manifest, out_dir='path/to/save/data/', label_col="species",
+train, val, test, stats = split.train_val_test(manifest, out_dir='path/to/save/data/', label_col="species",
                    percentage=(0.7, 0.2, 0.1), seed=None)
 ```
 

--- a/src/animl/generator.py
+++ b/src/animl/generator.py
@@ -2,7 +2,10 @@
 from PIL import Image, ImageOps, ImageFile
 import torch
 from torch.utils.data import Dataset, DataLoader
-from torchvision.transforms import (Compose, Resize, ToTensor, RandomHorizontalFlip, Normalize)
+from torchvision.transforms import (Compose, Resize, ToTensor, RandomHorizontalFlip,
+                                    Normalize, RandomHorizontalFlip, RandomAffine,
+                                    RandomGrayscale, RandomApply, ColorJitter,
+                                    GaussianBlur)
 from .utils.torch_utils import _setup_size
 
 ImageFile.LOAD_TRUNCATED_IMAGES = True
@@ -220,7 +223,7 @@ class TrainGenerator(Dataset):
         - resize: dynamically resize images to target (square)
     '''
     def __init__(self, x, classes, file_col='FilePath', label_col='species',
-                 crop=True, resize_height=299, resize_width=299):
+                 crop=True, resize_height=299, resize_width=299, augment=False):
         self.x = x
         self.resize_height = int(resize_height)
         self.resize_width = int(resize_width)
@@ -228,12 +231,33 @@ class TrainGenerator(Dataset):
         self.label_col = label_col
         self.buffer = 0
         self.crop = crop
-        self.transform = Compose([
-            # add augmentations
-            RandomHorizontalFlip(p=0.5),
-            Resize((self.resize_height, self.resize_width)),
-            ToTensor(),
+        augmentations = Compose([
+            # rotate between -10 to 10 degrees and shear between -5 to 5
+            RandomAffine(degrees=10, shear=(-5, 5)),
+            # convert images to grayscale with 50% probability
+            RandomGrayscale(p=0.5),
+            # apply gaussian blur with 50% probability 
+            RandomApply([GaussianBlur(kernel_size=3, sigma=(0.1, 0.5))], p=0.5),
+            # adjust brightness and contrast
+            ColorJitter(brightness=0.1, contrast=0.1),
         ])
+        if augment:
+            print("Augmenting images")
+            self.transform = Compose([
+                # add augmentations
+                augmentations,
+                # add random horizontal flip
+                RandomHorizontalFlip(p=0.5),
+                Resize((self.resize_height, self.resize_width)),
+                ToTensor(),
+            ])
+        else:
+            self.transform = Compose([
+                # add random horizontal flip
+                RandomHorizontalFlip(p=0.5),
+                Resize((self.resize_height, self.resize_width)),
+                ToTensor(),
+            ])
         self.categories = dict([[c, idx] for idx, c in list(enumerate(classes))])
 
     def __len__(self):
@@ -324,7 +348,7 @@ class LegacyGenerator(Dataset):
 
 
 def train_dataloader(manifest, classes, batch_size=1, workers=1, file_col="FilePath",
-                     crop=False, resize_height=299, resize_width=299):
+                     crop=False, resize_height=299, resize_width=299, augment=False):
     '''
         Loads a dataset for training and wraps it in a
         PyTorch DataLoader object. Shuffles the data before loading.
@@ -343,7 +367,8 @@ def train_dataloader(manifest, classes, batch_size=1, workers=1, file_col="FileP
             dataloader object
     '''
     dataset_instance = TrainGenerator(manifest, classes, file_col, crop=crop,
-                                      resize_height=resize_height, resize_width=resize_width)
+                                      resize_height=resize_height, resize_width=resize_width,
+                                      augment=augment)
 
     dataLoader = DataLoader(
             dataset=dataset_instance,

--- a/src/animl/generator.py
+++ b/src/animl/generator.py
@@ -231,30 +231,28 @@ class TrainGenerator(Dataset):
         self.label_col = label_col
         self.buffer = 0
         self.crop = crop
+        self.augment = augment
         augmentations = Compose([
-            # rotate between -10 to 10 degrees and shear between -5 to 5
-            RandomAffine(degrees=10, shear=(-5, 5)),
-            # convert images to grayscale with 50% probability
-            RandomGrayscale(p=0.5),
-            # apply gaussian blur with 50% probability 
-            RandomApply([GaussianBlur(kernel_size=3, sigma=(0.1, 0.5))], p=0.5),
-            # adjust brightness and contrast
-            ColorJitter(brightness=0.1, contrast=0.1),
+            # rotate ± 15 degrees and shear ± 7 degrees
+            RandomAffine(degrees=15, shear=(-7, 7)),
+            # convert images to grayscale with 20% probability
+            RandomGrayscale(p=0.2),
+            # apply gaussian blur with 30% probability 
+            RandomApply([GaussianBlur(kernel_size=3, sigma=(0.1, 1.0))], p=0.3),
+            # adjust brightness and contrast for varying lighting conditions
+            ColorJitter(brightness=0.2, contrast=0.2),
         ])
-        if augment:
-            print("Augmenting images")
+        if self.augment:
+            print("Applying augmentations")
             self.transform = Compose([
-                # add augmentations
-                augmentations,
-                # add random horizontal flip
-                RandomHorizontalFlip(p=0.5),
+                augmentations, # augmentations
+                RandomHorizontalFlip(p=0.5), # random horizontal flip
                 Resize((self.resize_height, self.resize_width)),
                 ToTensor(),
             ])
         else:
             self.transform = Compose([
-                # add random horizontal flip
-                RandomHorizontalFlip(p=0.5),
+                RandomHorizontalFlip(p=0.5), # random horizontal flip
                 Resize((self.resize_height, self.resize_width)),
                 ToTensor(),
             ])

--- a/src/animl/train.py
+++ b/src/animl/train.py
@@ -201,7 +201,7 @@ def main():
     optim = SGD(model.parameters(), lr=cfg['learning_rate'], weight_decay=cfg['weight_decay'])
     
     # initialize scheduler
-    scheduler = ReduceLROnPlateau(optim, mode='min', factor=0.5, patience=5, verbose=True)
+    scheduler = ReduceLROnPlateau(optim, mode='min', factor=0.5, patience=5)
 
     # initialize training arguments
     numEpochs = cfg['num_epochs']
@@ -261,6 +261,7 @@ def main():
         
         # step the scheduler with the validation loss
         scheduler.step(loss_val)
+        print(f"Learning rate: {print(scheduler.get_last_lr())}")
 
 if __name__ == '__main__':
     main()

--- a/src/animl/train.py
+++ b/src/animl/train.py
@@ -143,7 +143,7 @@ def validate(data_loader, model, device="cpu"):
             pred_labels.extend(pred_label_np)
 
             progressBar.set_description(
-                '[Val ] Loss: {:.2f}; OA: {:.2f}%'.format(
+                '[Val  ] Loss: {:.2f}; OA: {:.2f}%'.format(
                     loss_total/(idx+1),
                     100*oa_total/(idx+1)
                 )
@@ -264,7 +264,7 @@ def main():
         
         # step the scheduler with the validation loss
         scheduler.step(loss_val)
-        print(f"Learning rate: {print(scheduler.get_last_lr())}")
+        print(f"Learning rate for next epoch: {scheduler.get_last_lr()[0]}")
 
 if __name__ == '__main__':
     main()

--- a/src/animl/train.py
+++ b/src/animl/train.py
@@ -187,11 +187,13 @@ def main():
 
     categories = dict([[x["class"], x["id"]] for _, x in classes.iterrows()])
 
-    # initialize data loaders for training and validation set
+    # load datasets
     train_dataset = pd.read_csv(cfg['training_set']).reset_index(drop=True)
     validate_dataset = pd.read_csv(cfg['validate_set']).reset_index(drop=True)
-    dl_train = train_dataloader(train_dataset, categories, batch_size=cfg['batch_size'], workers=cfg['num_workers'], crop=crop)
-    dl_val = train_dataloader(validate_dataset, categories, batch_size=cfg['batch_size'], workers=cfg['num_workers'], crop=crop)
+    
+    # initialize data loaders for training and validation set
+    dl_train = train_dataloader(train_dataset, categories, batch_size=cfg['batch_size'], workers=cfg['num_workers'], crop=crop, augment=cfg.get('augment', False))
+    dl_val = train_dataloader(validate_dataset, categories, batch_size=cfg['batch_size'], workers=cfg['num_workers'], crop=crop, augment=False)
 
     # set up model optimizer
     optim = SGD(model.parameters(), lr=cfg['learning_rate'], weight_decay=cfg['weight_decay'])

--- a/src/animl/train.py
+++ b/src/animl/train.py
@@ -15,6 +15,8 @@ import torch
 from torch.backends import cudnn
 from torch.optim import SGD
 from sklearn.metrics import precision_score, recall_score
+from torch.optim.lr_scheduler import ReduceLROnPlateau
+
 
 from .generator import train_dataloader
 from .classifiers import save_model, load_model
@@ -197,6 +199,9 @@ def main():
 
     # set up model optimizer
     optim = SGD(model.parameters(), lr=cfg['learning_rate'], weight_decay=cfg['weight_decay'])
+    
+    # initialize scheduler
+    scheduler = ReduceLROnPlateau(optim, mode='min', factor=0.5, patience=5, verbose=True)
 
     # initialize training arguments
     numEpochs = cfg['num_epochs']
@@ -253,6 +258,9 @@ def main():
             if epochs_no_improve >= patience:
                 print(f"Early stopping triggered after {patience} epochs without improvement.")
                 break
+        
+        # step the scheduler with the validation loss
+        scheduler.step(loss_val)
 
 if __name__ == '__main__':
     main()

--- a/src/animl/train.py
+++ b/src/animl/train.py
@@ -204,7 +204,7 @@ def main():
     optim = SGD(model.parameters(), lr=cfg['learning_rate'], weight_decay=cfg['weight_decay'])
     
     # initialize scheduler
-    scheduler = ReduceLROnPlateau(optim, mode='min', factor=0.5, patience=5)
+    scheduler = ReduceLROnPlateau(optim, mode='min', factor=0.5, patience=3)
 
     # initialize training arguments
     numEpochs = cfg['num_epochs']
@@ -221,6 +221,7 @@ def main():
     while current_epoch < numEpochs:
         current_epoch += 1
         print(f'Epoch {current_epoch}/{numEpochs}')
+        print(f"Using learning rate : {scheduler.get_last_lr()[0]}")
 
         loss_train, oa_train = train(dl_train, model, optim, device)
         loss_val, oa_val, precision, recall = validate(dl_val, model, device)
@@ -250,7 +251,11 @@ def main():
                 best_val_loss = loss_val
                 epochs_no_improve = 0
                 save_model(cfg['experiment_folder'], 'best', model, stats)
-                print(f"Current best model saved at epoch {current_epoch} with val loss {best_val_loss:.3f}, val OA {oa_val:.3f}, val precision {precision:.3f}, val recall {recall:.3f}")
+                print(f"Current best model saved at epoch {current_epoch} with ...")
+                print(f"     val loss : {best_val_loss:.5f}")
+                print(f"       val OA : {oa_val:.5f}")
+                print(f"val precision : {precision:.5f}")
+                print(f"   val recall : {recall:.5f}\n")
             else:
                 epochs_no_improve += 1
 
@@ -264,7 +269,6 @@ def main():
         
         # step the scheduler with the validation loss
         scheduler.step(loss_val)
-        print(f"Learning rate for next epoch: {scheduler.get_last_lr()[0]}")
 
 if __name__ == '__main__':
     main()

--- a/src/animl/train.py
+++ b/src/animl/train.py
@@ -5,6 +5,9 @@
     Original script from
     2022 Benjamin Kellenberger
 '''
+
+# TODO: get scheduler bool from config file... now it is hard coded.
+
 import argparse
 import yaml
 from tqdm import trange


### PR DESCRIPTION
Added extra options that can be user specified during training:

1. **ConvNeXt** - I added the 'convnext_base' model with pre-trained ImageNet weights to retrain from. This model architecture has proven very efficient (see [Deepfaune paper](https://link.springer.com/article/10.1007/s10344-023-01742-7)). Can be chosen by specifying `architecture: "convnext_base"` in config file.
2. **Early stopping** - There is now the option to set a patience value. If specified (e.g., `patience: 10`) it will save `last.pt` each epoch and `best.pt` only if it has a lower val loss than the previous best model. 
3. **Augmentations** - I added the option to add extra augmentations if desired. These augmentation methods are also used in the Deepfaune model (see [Deepfaune paper](https://link.springer.com/article/10.1007/s10344-023-01742-7)). Can be specified with `augment: True` in the config file. Will only affect the train batches, never test or val. 

I hope these suggestions prove to be valuable! 