### PR TITLE
fix: resolve bugs when running train_classifier

### DIFF
--- a/src/animl/file_management.py
+++ b/src/animl/file_management.py
@@ -369,7 +369,7 @@ def class_list_to_dict(class_list: pd.DataFrame,
         class_list (pd.DataFrame): dataframe with 'class' and 'id' columns
 
     Returns:
-        class_dict (dict): dictionary mapping class names to ids
+        class_dict (dict): dictionary mapping ids to class names
     """
     if not {class_col, id_col}.issubset(class_list.columns):
         raise ValueError(f"DataFrame must contain '{class_col}' and '{id_col}' columns.")

--- a/src/animl/generator.py
+++ b/src/animl/generator.py
@@ -345,7 +345,7 @@ class TrainGenerator(Dataset):
             self.transform = Compose([Resize((self.resize_height, self.resize_width)),
                                       ToImage(),
                                       ToDtype(torch.float32, scale=True),])
-        self.categories = dict([[c, idx] for idx, c in list(enumerate(classes))])
+        self.categories = {c: idx for idx, c in classes.items()}
 
     def __len__(self):
         return len(self.x)

--- a/src/animl/train.py
+++ b/src/animl/train.py
@@ -156,11 +156,12 @@ def _train_classifier_helper(data_loader, model, optimizer, scheduler, device='c
         scaler = GradScaler('cuda', enabled=True)
 
     for idx, batch in enumerate(data_loader):
-        if batch is None:  # entire batch was bad
+        collated, failed = batch
+        if collated is None:  # entire batch was bad
             continue
         # put data and labels on device
-        data = batch[0]
-        labels = batch[1]
+        data = collated[0]
+        labels = collated[1]
         data, labels = data.to(device), labels.to(device)
         # reset gradients to zero
         optimizer.zero_grad()
@@ -250,10 +251,11 @@ def _validate_classifier_helper(data_loader, model, device="cpu", progress=True)
         progressBar = trange(len(data_loader))
     with torch.no_grad():  # gradients not necessary for validation
         for idx, batch in enumerate(data_loader):
-            if batch is None:  # entire batch was bad
+            collated, failed = batch
+            if collated is None:  # entire batch was bad
                 continue
-            data = batch[0]
-            labels = batch[1]
+            data = collated[0]
+            labels = collated[1]
             data, labels = data.to(device), labels.to(device)
 
             # add true labels to the true labels list

--- a/src/animl/train.py
+++ b/src/animl/train.py
@@ -351,8 +351,8 @@ def train_classifier(cfg):
     model.to(device)
     print(f"Model moved to {device}")
 
-    categories = file_management.class_list_to_dict(classes, index_col=cfg.get('class_list_index', 'id'),
-                                                    label_col=cfg.get('class_list_label', 'class'))
+    categories = file_management.class_list_to_dict(classes, id_col=cfg.get('class_list_index', 'id'),
+                                                    class_col=cfg.get('class_list_label', 'class'))
 
     # load datasets
     train_dataset = file_management.load_data(cfg['training_set'])


### PR DESCRIPTION
Fix mismatch where training and validation loops expect (data, labels, image names) from dataloader rather than (collated, failed) returned by the custom collate_fn.

Closes #290