### PR TITLE
fix: gradscaler initialization

### DIFF
--- a/src/animl/train.py
+++ b/src/animl/train.py
@@ -121,7 +121,7 @@ def load_classifier_checkpoint(model_path, model, optimizer, scheduler, device):
         return 0
 
 
-def _train_classifier_helper(data_loader, model, optimizer, scheduler, device='cpu',
+def _train_classifier_helper(data_loader, model, optimizer, scheduler, scaler=None, device='cpu',
                              mixed_precision=False, progress=True):
     '''
     Main training loop.
@@ -131,6 +131,7 @@ def _train_classifier_helper(data_loader, model, optimizer, scheduler, device='c
         model: loaded model object
         optimizer: optimizer object
         scheduler: learning rate scheduler
+        scaler: GradScaler object
         device (str): device to load model and data to
         mixed_precision (bool): flag to enable mixed precision for GPU
         progress (bool): flag to enable/disable progress bar
@@ -151,10 +152,6 @@ def _train_classifier_helper(data_loader, model, optimizer, scheduler, device='c
     if progress:
         progressBar = trange(len(data_loader))
 
-    if mixed_precision and device != 'cpu' and torch.cuda.is_available():
-        # Creates a GradScaler once at the beginning of training.
-        scaler = GradScaler('cuda', enabled=True)
-
     for idx, batch in enumerate(data_loader):
         collated, failed = batch
         if collated is None:  # entire batch was bad
@@ -167,7 +164,7 @@ def _train_classifier_helper(data_loader, model, optimizer, scheduler, device='c
         optimizer.zero_grad()
 
         # mixed precision training if GPU is available
-        if mixed_precision and device != 'cpu' and torch.cuda.is_available():
+        if mixed_precision and device != 'cpu' and torch.cuda.is_available() and scaler is not None:
             # Scales the loss, and calls backward() on the scaled loss to create
             # backward gradients. This is a more efficient way to calculate gradients.
             with autocast(device_type='cuda', dtype=torch.float16):
@@ -385,6 +382,12 @@ def train_classifier(cfg):
     else:  # do nothing scheduler
         scheduler = LambdaLR(optim, lr_lambda=lambda epoch: 1)
 
+    if mixed_precision and device != 'cpu' and torch.cuda.is_available():
+        # Creates a GradScaler once at the beginning of training.
+        scaler = GradScaler('cuda', enabled=True)
+    else:
+        scaler = None
+
     # Load checkpoint for model weights, optimizer state, scheduler state, and actual current_epoch
     current_epoch = load_classifier_checkpoint(cfg['experiment_folder'], model, optim, scheduler, device=device)
 
@@ -417,7 +420,7 @@ def train_classifier(cfg):
             for param in model.parameters():
                 param.requires_grad = True
 
-        loss_train, oa_train = _train_classifier_helper(dl_train, model, optim, scheduler, device,
+        loss_train, oa_train = _train_classifier_helper(dl_train, model, optim, scheduler, scaler=scaler, device=device,
                                                         mixed_precision=mixed_precision, progress=progress)
         loss_val, oa_val, precision, recall = _validate_classifier_helper(dl_val, model, device, progress=progress)
 

--- a/src/animl/train.py
+++ b/src/animl/train.py
@@ -35,7 +35,8 @@ def save_classifier(model,
                     epoch: int,
                     stats: dict,
                     optimizer=None,
-                    scheduler=None):
+                    scheduler=None,
+                    scaler=None):
     '''
     Saves model state weights.
 
@@ -46,6 +47,7 @@ def save_classifier(model,
         stats (dict): performance metrics of current epoch
         optimizer: pytorch optimizer (optional)
         scheduler: pytorch scheduler (optional)
+        scaler: pytorch GradScaler (optional)
 
     Returns:
         None
@@ -62,11 +64,13 @@ def save_classifier(model,
         checkpoint['optimizer'] = optimizer.state_dict()
     if scheduler is not None:
         checkpoint['scheduler'] = scheduler.state_dict()
+    if scaler is not None:
+        checkpoint['scaler'] = scaler.state_dict()
 
     torch.save(checkpoint, open(f'{out_dir}/{epoch}.pt', 'wb'))
 
 
-def load_classifier_checkpoint(model_path, model, optimizer, scheduler, device):
+def load_classifier_checkpoint(model_path, model, optimizer, scheduler, scaler, device):
     '''
     Load checkpoint model weights to resume training.
 
@@ -75,6 +79,7 @@ def load_classifier_checkpoint(model_path, model, optimizer, scheduler, device):
         model: loaded model object
         optimizer: optimizer object
         scheduler: learning rate scheduler
+        scaler: GradScaler object or None if not using GradScaler
         device (str): device to load model and data to
 
     Returns:
@@ -109,6 +114,9 @@ def load_classifier_checkpoint(model_path, model, optimizer, scheduler, device):
         # load scheduler state if available
         if 'scheduler' in checkpoint:
             scheduler.load_state_dict(checkpoint['scheduler'])
+
+        if 'scaler' in checkpoint and scaler is not None:
+            scaler.load_state_dict(checkpoint['scaler'])
 
         # get last epoch from model if avialble
         if 'epoch' in checkpoint:
@@ -389,7 +397,7 @@ def train_classifier(cfg):
         scaler = None
 
     # Load checkpoint for model weights, optimizer state, scheduler state, and actual current_epoch
-    current_epoch = load_classifier_checkpoint(cfg['experiment_folder'], model, optim, scheduler, device=device)
+    current_epoch = load_classifier_checkpoint(cfg['experiment_folder'], model, optim, scheduler, scaler, device=device)
 
     # initialize training arguments
     numEpochs = cfg['num_epochs']
@@ -449,7 +457,7 @@ def train_classifier(cfg):
             experiment.log_metrics(stats, step=current_epoch)
 
         if current_epoch % checkpoint == 0:
-            save_classifier(model, cfg['experiment_folder'], current_epoch, stats, optim, scheduler)
+            save_classifier(model, cfg['experiment_folder'], current_epoch, stats, optim, scheduler, scaler)
 
         # best.pt saving
         if loss_val < best_val_loss:


### PR DESCRIPTION
Resolves the bug documented in #298 where GradScaler is being initialized once per epoch instead of once per training session. Also updates `save_classifier` and `load_classifier_checkpoint` to save and load the scaler's state dict

Closes #298