### PR TITLE
311 update save_data

### DIFF
--- a/src/animl/file_management.py
+++ b/src/animl/file_management.py
@@ -218,7 +218,8 @@ class WorkingDirectory():
 
 def save_data(data: pd.DataFrame,
               out_file: Union[Path, str],
-              prompt: bool = True) -> None:
+              prompt: bool = True,
+              index: bool = False) -> None:
     """
     Save data to given file.
 
@@ -226,6 +227,7 @@ def save_data(data: pd.DataFrame,
         data (pd.DataFrame): the dataframe to be saved
         out_file (Union[Path, str]): full path to save file to
         prompt (bool): prompts the user to confirm overwrite
+        index (bool): if True, saves the indices in the output file
 
     Returns:
         None
@@ -236,7 +238,7 @@ def save_data(data: pd.DataFrame,
             return
     else:
         if Path(out_file).parent.exists():
-            data.to_csv(out_file, index=False)
+            data.to_csv(out_file, index=index)
         else:
             raise AssertionError('Cannot save, directory does not exis.')
 

--- a/src/animl/file_management.py
+++ b/src/animl/file_management.py
@@ -236,11 +236,11 @@ def save_data(data: pd.DataFrame,
         prompt = "Output file exists, would you like to overwrite? y/n: "
         if input(prompt).lower() != "y":
             return
+
+    if Path(out_file).parent.exists():
+        data.to_csv(out_file, index=index)
     else:
-        if Path(out_file).parent.exists():
-            data.to_csv(out_file, index=index)
-        else:
-            raise AssertionError('Cannot save, directory does not exis.')
+        raise AssertionError('Cannot save, directory does not exist.')
 
 
 def load_data(file: Union[Path, str]) -> pd.DataFrame:

--- a/src/animl/test.py
+++ b/src/animl/test.py
@@ -128,7 +128,7 @@ def test_classifier(cfg):
 
     cm = confusion_matrix(true, pred)
     confuse = pd.DataFrame(cm, columns=classes[class_list_label], index=classes[class_list_label])
-    file_management.save_data(confuse, cfg['experiment_folder'] + "/confusion_matrix.csv")
+    file_management.save_data(confuse, cfg['experiment_folder'] + "/confusion_matrix.csv", index=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Updates the `save_data` function in `file_management.py` to have an option to save csvs with index=True
* Fixes a bug in `save_data` where the file wasn't being overwritten when prompt=True.
* Saves the confusion matrix in `test.py` with index=True so the class labels column is saved

Documented in more detail in #311 

Closes #311 