### PR TITLE
315 mixed precision datatype

### DIFF
--- a/examples/Cats_vs_Dogs/cat_dog_train.yml
+++ b/examples/Cats_vs_Dogs/cat_dog_train.yml
@@ -38,6 +38,7 @@ momentum: 0.9 # only for SGD
 scheduler: True # CosineAnnealingLR
 t_max: 10 # number of epochs for the scheduler, usualy the same as num_epochs
 mixed_precision: True # True or False, if you have a GPU with Tensor Cores (NVIDIA Volta, Turing, or Ampere architecture), set to True
+precision_dtype: float16 # bfloat16 or float16 for mixed precision (bfloat16 requires NVIDIA Ampere or newer)
 
 # overwrite .pt files
 overwrite: False

--- a/src/animl/config/train.yml
+++ b/src/animl/config/train.yml
@@ -42,6 +42,7 @@ momentum: 0.9 # only for SGD
 scheduler: True # CosineAnnealingLR
 t_max: 40 # number of epochs for the scheduler, usualy the same as num_epochs
 mixed_precision: True # True or False, if you have a GPU with Tensor Cores (NVIDIA Volta, Turing, or Ampere architecture), set to True
+precision_dtype: float16 # bfloat16 or float16 for mixed precision (bfloat16 requires NVIDIA Ampere or newer)
 
 # overwrite .pt files
 overwrite: False

--- a/src/animl/train.py
+++ b/src/animl/train.py
@@ -130,7 +130,7 @@ def load_classifier_checkpoint(model_path, model, optimizer, scheduler, scaler, 
 
 
 def _train_classifier_helper(data_loader, model, optimizer, scheduler, scaler=None, device='cpu',
-                             mixed_precision=False, progress=True):
+                             mixed_precision=False, precision_dtype=torch.float16, progress=True):
     '''
     Main training loop.
 
@@ -142,12 +142,17 @@ def _train_classifier_helper(data_loader, model, optimizer, scheduler, scaler=No
         scaler: GradScaler object
         device (str): device to load model and data to
         mixed_precision (bool): flag to enable mixed precision for GPU
+        precision_dtype (torch.dtype): datatype for mixed precision
         progress (bool): flag to enable/disable progress bar
 
     Returns:
         loss_total: loss for epoch
         oa_total: overall accuracy for epoch
     '''
+    # Ensure float16 always has a scaler to prevent numeric underflow/crashes
+    if mixed_precision and precision_dtype == torch.float16:
+        assert scaler is not None, "GradScaler must be provided for float16 mixed precision"
+
     model.to(device)
     model.train()  # put the model into training mode
 
@@ -171,13 +176,22 @@ def _train_classifier_helper(data_loader, model, optimizer, scheduler, scaler=No
         # reset gradients to zero
         optimizer.zero_grad()
 
+        # forward pass and loss calculation
         # mixed precision training if GPU is available
-        if mixed_precision and device != 'cpu' and torch.cuda.is_available() and scaler is not None:
-            # Scales the loss, and calls backward() on the scaled loss to create
-            # backward gradients. This is a more efficient way to calculate gradients.
-            with autocast(device_type='cuda', dtype=torch.float16):
+        if mixed_precision and device != 'cpu' and torch.cuda.is_available():
+            with autocast(device_type='cuda', dtype=precision_dtype):
                 prediction = model(data)
                 loss = criterion(prediction, labels)
+        else:
+            # forward pass
+            prediction = model(data)
+            # loss
+            loss = criterion(prediction, labels)
+
+        # backward pass
+        if mixed_precision and precision_dtype == torch.float16:
+            # Due to float16's limited range, it scales
+            # the loss and gradient calculation to prevent underflow
             scaler.scale(loss).backward()
             # Unscales the gradients of optimizer's assigned params in-place
             scaler.unscale_(optimizer)
@@ -186,10 +200,6 @@ def _train_classifier_helper(data_loader, model, optimizer, scheduler, scaler=No
             # Updates the scale for next iteration
             scaler.update()
         else:
-            # forward pass
-            prediction = model(data)
-            # loss
-            loss = criterion(prediction, labels)
             # calculate gradients of current batch
             loss.backward()
             # apply gradients to model parameters

--- a/src/animl/train.py
+++ b/src/animl/train.py
@@ -348,6 +348,14 @@ def train_classifier(cfg):
         device = 'cpu'
     # get mixed precision flag
     mixed_precision = cfg.get('mixed_precision', False)
+    precision_dtype = cfg.get('precision_dtype','float16')
+
+    if precision_dtype == 'bfloat16':
+        precision_dtype = torch.bfloat16
+        if mixed_precision:
+            assert torch.cuda.is_bf16_supported(), "bfloat16 not natively supported on this GPU"
+    else:
+        precision_dtype = torch.float16
 
     # model will be on CPU after this call if cfg['experiment_folder'] is a directory
     model, classes, current_epoch = load_classifier(cfg['experiment_folder'], cfg['class_file'],
@@ -393,7 +401,7 @@ def train_classifier(cfg):
     else:  # do nothing scheduler
         scheduler = LambdaLR(optim, lr_lambda=lambda epoch: 1)
 
-    if mixed_precision and device != 'cpu' and torch.cuda.is_available():
+    if mixed_precision and device != 'cpu' and torch.cuda.is_available() and precision_dtype==torch.float16:
         # Creates a GradScaler once at the beginning of training.
         scaler = GradScaler('cuda', enabled=True)
     else:
@@ -431,8 +439,11 @@ def train_classifier(cfg):
             for param in model.parameters():
                 param.requires_grad = True
 
-        loss_train, oa_train = _train_classifier_helper(dl_train, model, optim, scheduler, scaler=scaler, device=device,
-                                                        mixed_precision=mixed_precision, progress=progress)
+        loss_train, oa_train = _train_classifier_helper(dl_train, model, optim, scheduler,
+                                                        scaler=scaler, device=device,
+                                                        mixed_precision=mixed_precision,
+                                                        precision_dtype=precision_dtype,
+                                                        progress=progress)
         loss_val, oa_val, precision, recall = _validate_classifier_helper(dl_val, model, device, progress=progress)
 
         # combine stats and save


### PR DESCRIPTION
Adds an option to choose mixed precision datatype in the training configuration. The options are `float16` or `bfloat16`. 

* Reads `precision_dtype` from the configuration, keeping `float16` as the default
* Updates backpropagation to only utilize GradScaler when `float16` mixed precision is used, because `bfloat16` mixed precision doesn't require GradScaler
* Adds assertions to ensure selected precision datatype is compatible with hardware, and that GradScaler is present for `float16` mixed precision

Closes #315 