### PR TITLE
328 model architecture updates

### DIFF
--- a/src/animl/model_architecture.py
+++ b/src/animl/model_architecture.py
@@ -22,7 +22,6 @@ class EfficientNet(nn.Module):
     def __init__(self, num_classes, device=None, tune=False):
         super(EfficientNet, self).__init__()
         self.device = device
-        self.avgpool = nn.AdaptiveAvgPool2d(1)
         # "pretrained": use weights pre-trained on ImageNet
         self.model = efficientnet.efficientnet_v2_m(weights=efficientnet.EfficientNet_V2_M_Weights.DEFAULT)
         if tune:
@@ -41,13 +40,7 @@ class EfficientNet(nn.Module):
         Forward pass (prediction)
         '''
         # x.size(): [B x 3 x W x H]
-        x = self.model.features(x)
-        x = self.avgpool(x)
-        x = torch.flatten(x, 1)
-
-        prediction = self.model.classifier(x)  # prediction.size(): [B x num_classes]
-
-        return prediction
+        return self.model(x)
 
 
 class ConvNeXtBase(nn.Module):

--- a/src/animl/model_architecture.py
+++ b/src/animl/model_architecture.py
@@ -54,7 +54,7 @@ class ConvNeXtBase(nn.Module):
     '''
     Construct the ConvNeXt-Base model architecture.
     '''
-    def __init__(self, num_classes, tune=True):
+    def __init__(self, num_classes, tune=False):
         super(ConvNeXtBase, self).__init__()
         # load the ConvNeXt-Base model pre-trained on ImageNet 1K
         self.model = convnext_base(weights=ConvNeXt_Base_Weights.DEFAULT)


### PR DESCRIPTION
* Changes the default value of the tune argument for ConvNeXt from True to False (to match behavior of other model architecture implementations and ensure frozen epochs during training behaves as expected)
* Simplifies EfficientNet's forward function by replacing it with `return self.model(x)`
  * Confirmed this results in identical behavior by looking at the PyTorch implementation of EfficientNet, and also checking that it yields identical results on a test dataset


Closes #328 